### PR TITLE
Feature: Add Docker image build configuration to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 		<url/>
 	</scm>
 	<properties>
-		<docker.image.name>autocare-rest-api:latest</docker.image.name>
+		<docker.image.name>${project.groupId}/${project.artifactId}:${project.version}</docker.image.name>
 		<java.version>17</java.version>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 		<springdoc.version>2.2.0</springdoc.version>
@@ -106,13 +106,6 @@
 					<imageName>${docker.image.name}</imageName> <!-- You can change this -->
 
 				</configuration>
-				<executions>
-					<execution>
-						<goals>
-							<goal>build-image</goal>
-						</goals>
-					</execution>
-				</executions>
 
 			</plugin>
 			<plugin>
@@ -206,4 +199,25 @@
 			</plugin>
 		</plugins>
 	</build>
+	<profiles>
+		<profile>
+			<id>docker-build</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.springframework.boot</groupId>
+						<artifactId>spring-boot-maven-plugin</artifactId>
+						<executions>
+							<execution>
+								<goals>
+									<goal>build-image</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
 		<url/>
 	</scm>
 	<properties>
+		<docker.image.name>autocare-rest-api:latest</docker.image.name>
 		<java.version>17</java.version>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 		<springdoc.version>2.2.0</springdoc.version>
@@ -102,7 +103,17 @@
 							<artifactId>lombok</artifactId>
 						</exclude>
 					</excludes>
+					<imageName>${docker.image.name}</imageName> <!-- You can change this -->
+
 				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>build-image</goal>
+						</goals>
+					</execution>
+				</executions>
+
 			</plugin>
 			<plugin>
 				<groupId>com.diffplug.spotless</groupId>


### PR DESCRIPTION
Introduced a docker.image.name property and configured the Maven plugin to build a Docker image with the specified name. This streamlines the Docker image creation process as part of the Maven build lifecycle.
This Fixes Issue #32