### PR TITLE
moved password storage from in-code to environment properties

### DIFF
--- a/src/main/java/com/frg/autocare/AutoCareApplication.java
+++ b/src/main/java/com/frg/autocare/AutoCareApplication.java
@@ -17,10 +17,13 @@
  */
 package com.frg.autocare;
 
+import com.frg.autocare.configs.ApplicationProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 @SpringBootApplication
+@EnableConfigurationProperties(ApplicationProperties.class)
 public class AutoCareApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/com/frg/autocare/configs/ApplicationProperties.java
+++ b/src/main/java/com/frg/autocare/configs/ApplicationProperties.java
@@ -1,0 +1,8 @@
+package com.frg.autocare.configs;
+
+import jakarta.validation.constraints.NotEmpty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "autocare-rest-api")
+public record ApplicationProperties(
+    @NotEmpty(message = "password must not be empty") String dummyUserPassword) {}

--- a/src/main/java/com/frg/autocare/configs/LoadDatabaseConfig.java
+++ b/src/main/java/com/frg/autocare/configs/LoadDatabaseConfig.java
@@ -29,7 +29,6 @@ import com.frg.autocare.repository.MaintainerRepository;
 import com.frg.autocare.repository.ToolRepository;
 import com.frg.autocare.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -42,9 +41,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 public class LoadDatabaseConfig {
 
   private final PasswordEncoder passwordEncoder;
-
-  @Value("${data.DUMMY_ADMIN_USER_PASSWORD}")
-  private String password;
+  private ApplicationProperties applicationProperties;
 
   @Bean
   CommandLineRunner initDatabase(
@@ -52,12 +49,14 @@ public class LoadDatabaseConfig {
       CarRepository carRepository,
       CustomerRepository customerRepository,
       MaintainerRepository maintainerRepository,
-      ToolRepository toolRepository) {
+      ToolRepository toolRepository,
+      ApplicationProperties applicationProperties) {
     return args -> {
+      this.applicationProperties = applicationProperties;
       User user1 = new User();
       user1.setName("John Doe");
       user1.setEmail("john.doe@example.com");
-      user1.setPassword(passwordEncoder.encode(password));
+      user1.setPassword(passwordEncoder.encode(this.applicationProperties.dummyUserPassword()));
       user1.setRole(Role.ADMIN);
       userRepository.save(user1);
 

--- a/src/main/java/com/frg/autocare/configs/LoadDatabaseConfig.java
+++ b/src/main/java/com/frg/autocare/configs/LoadDatabaseConfig.java
@@ -29,6 +29,7 @@ import com.frg.autocare.repository.MaintainerRepository;
 import com.frg.autocare.repository.ToolRepository;
 import com.frg.autocare.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -42,6 +43,9 @@ public class LoadDatabaseConfig {
 
   private final PasswordEncoder passwordEncoder;
 
+  @Value("${data.DUMMY_ADMIN_USER_PASSWORD}")
+  private String password;
+
   @Bean
   CommandLineRunner initDatabase(
       UserRepository userRepository,
@@ -53,7 +57,7 @@ public class LoadDatabaseConfig {
       User user1 = new User();
       user1.setName("John Doe");
       user1.setEmail("john.doe@example.com");
-      user1.setPassword(passwordEncoder.encode("password123"));
+      user1.setPassword(passwordEncoder.encode(password));
       user1.setRole(Role.ADMIN);
       userRepository.save(user1);
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -80,5 +80,5 @@ app:
     expiration: ${JWT_EXPIRATION:86400000} # 24 hours
 
 # Define Dummy User Password
-data:
-  DUMMY_ADMIN_USER_PASSWORD: password123
+autocare-rest-api:
+  dummyUserPassword: ${DUMMY_ADMIN_USER_PASSWORD:password123}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -78,3 +78,7 @@ app:
   jwt:
     secret: ${JWT_SECRET:404E635266556A586E3272357538782F413F4428472B4B6250645367566B5970} # Default secret key, can be overridden by environment variable
     expiration: ${JWT_EXPIRATION:86400000} # 24 hours
+
+# Define Dummy User Password
+data:
+  DUMMY_ADMIN_USER_PASSWORD: password123


### PR DESCRIPTION
 Title of Issue  :  Password defined explicitly in code #39

Stored the password as an environment variable  DUMMY_ADMIN_USER_PASSWORD in the application.yaml since it was being flagged as a security vulnerability .

